### PR TITLE
Fix 36.2: enum types in the dump, 64-bit gc handles, game data directory

### DIFF
--- a/.github/workflows/AndroidMixMod.yml
+++ b/.github/workflows/AndroidMixMod.yml
@@ -9,6 +9,8 @@ jobs:
 
     env:
       DOTNET_ROLL_FORWARD: "LatestMajor"
+      # pinned so patches/Il2CppDumper-enum-metadata-v32plus.patch keeps applying
+      IL2CPPDUMPER_COMMIT: "7c4a19426e2c17cfaa6e0a5b37f35869a93fad21"
 
     steps:
 
@@ -128,24 +130,32 @@ jobs:
         working-directory: ${{ env.Downloads_Dir }}/${{ env.apk_folder_name }}/
         run: git apply --unidiff-zero ${{ github.workspace }}/0001-AndroidMixMod.patch
         
-      - name: Get Il2CppDumper latest release info
-        run: |
-          curl --silent https://api.github.com/repos/c01ns/Il2CppDumper/releases/latest >> ${{ runner.temp }}/Il2CppDumper_release_info.json
-          echo "Il2CppDumper_asset_id=$(jq -r '.assets[0] | .id' ${{ runner.temp }}/Il2CppDumper_release_info.json)" >> $GITHUB_ENV
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Cache Il2CppDumper
         id: Il2CppDumper-cache
         uses: actions/cache@v5
         with:
           path: ${{ env.Downloads_Dir }}/Il2CppDumper
-          key: Il2CppDumper-${{ runner.os }}-${{ env.Il2CppDumper_asset_id }}
-          
-      - name: Download Il2CppDumper
+          key: Il2CppDumper-${{ runner.os }}-${{ env.IL2CPPDUMPER_COMMIT }}-${{ hashFiles('patches/Il2CppDumper-enum-metadata-v32plus.patch') }}
+
+      # The released build of c01ns/Il2CppDumper cannot resolve enum underlying types on metadata >= 32:
+      # Il2CppTypeDefinition.elementTypeIndex was removed there, so every enum field/parameter is emitted
+      # as an 8-byte Il2CppObject* instead of int32_t. That silently shifts every struct layout in il2cpp.h.
+      # Build from source with the fix applied instead.
+      - name: Build patched Il2CppDumper
         if: steps.Il2CppDumper-cache.outputs.cache-hit != 'true'
         working-directory: ${{ env.Downloads_Dir }}
         run: |
-          wget $(jq -r '.assets[0] | .browser_download_url' ${{ runner.temp }}/Il2CppDumper_release_info.json) -O ./Il2CppDumper.zip
-          unzip -q -j Il2CppDumper.zip -d Il2CppDumper 2> /dev/null || true
+          git clone https://github.com/c01ns/Il2CppDumper.git Il2CppDumperSrc
+          cd Il2CppDumperSrc
+          git checkout ${{ env.IL2CPPDUMPER_COMMIT }}
+          git apply --verbose ${{ github.workspace }}/patches/Il2CppDumper-enum-metadata-v32plus.patch
+          dotnet publish Il2CppDumper/Il2CppDumper.csproj -c Release -f net8.0 -o ../Il2CppDumper
+          cd ..
           sed -i "s/\"GenerateDummyDll\": true/\"GenerateDummyDll\": false/" ./Il2CppDumper/config.json
           sed -i "s/\"RequireAnyKey\": true/\"RequireAnyKey\": false/" ./Il2CppDumper/config.json
           
@@ -179,6 +189,20 @@ jobs:
           cp ./armeabi-v7a/il2cpp.h ${{ github.workspace }}/app/src/main/jni/Includes/armeabi-v7a
           sed -i "s/std\(in\|out\|err\)/_std\1/g" ${{ github.workspace }}/app/src/main/jni/Includes/arm64-v8a/il2cpp.h
           sed -i "s/std\(in\|out\|err\)/_std\1/g" ${{ github.workspace }}/app/src/main/jni/Includes/armeabi-v7a/il2cpp.h
+
+      # Guard against a dumper that cannot resolve enum underlying types: it emits enum fields as
+      # 8-byte pointers, which shifts every struct layout in il2cpp.h and makes _this->fields.X
+      # read/write the wrong offsets at runtime (silent memory corruption, not a build error).
+      - name: Check il2cpp.h enum fields
+        working-directory: ${{ github.workspace }}/app/src/main/jni/Includes/
+        run: |
+          for abi in arm64-v8a armeabi-v7a; do
+            if ! grep -q "^	int32_t m_realTimePremium;$" $abi/il2cpp.h; then
+              echo "$abi/il2cpp.h: Entity.m_realTimePremium is not an int32_t - the dumper failed to resolve enum types, struct layouts are shifted"
+              grep -n "m_realTimePremium" $abi/il2cpp.h || true
+              exit 1
+            fi
+          done
 
       - name: Generate offsets
         working-directory: ${{ env.Downloads_Dir }}

--- a/0001-AndroidMixMod.patch
+++ b/0001-AndroidMixMod.patch
@@ -14,37 +14,6 @@
 -    move-result v3
 +    const/4 v3, 0x1
  
---- a/smali/com/blizzard/wtcg/hearthstone/FileUtils.smali
-+++ b/smali/com/blizzard/wtcg/hearthstone/FileUtils.smali
-@@ -1753,3 +1753,19 @@
- .method public static GetInternalFilesDir()Ljava/io/File;
--    .locals 1
-+    .locals 2
-+
-+    invoke-static {}, Lcom/blizzard/wtcg/hearthstone/HearthstoneApplication;->getInstance()Lcom/blizzard/wtcg/hearthstone/HearthstoneApplication;
-+
-+    move-result-object v0
-+
-+    invoke-virtual {v0}, Lcom/blizzard/wtcg/hearthstone/HearthstoneApplication;->getApplicationContext()Landroid/content/Context;
-+
-+    move-result-object v0
-+
-+    const/4 v1, 0x0
-+
-+    invoke-virtual {v0, v1}, Landroid/content/Context;->getExternalFilesDir(Ljava/lang/String;)Ljava/io/File;
-+
-+    move-result-object v0
-+
-+    if-nez v0, :cond_0
- 
-@@ -1782,6 +1782,7 @@
- 
-     move-result-object v0
- 
-+    :cond_0
-     return-object v0
- .end method
- 
 --- a/smali/com/blizzard/wtcg/hearthstone/HearthstoneActivity.smali
 +++ b/smali/com/blizzard/wtcg/hearthstone/HearthstoneActivity.smali
 @@ -610,3 +610,7 @@

--- a/OffsetsTemplate.json
+++ b/OffsetsTemplate.json
@@ -189,7 +189,7 @@
     "$type": "Generator.OffsetLines.SignatureLine, Generator",
     "Section": 0,
     "Text": "#define SocialToastMgr_AddToast_Offset \"0x{0:X}\"",
-    "Signature": "void SocialToastMgr__AddToast (SocialToastMgr_o* __this, Il2CppObject* blocker, System_String_o* textArg, Il2CppObject* toastType, float displayTime, bool playSound, const MethodInfo* method);"
+    "Signature": "void SocialToastMgr__AddToast (SocialToastMgr_o* __this, int32_t blocker, System_String_o* textArg, int32_t toastType, float displayTime, bool playSound, const MethodInfo* method);"
   },
   {
     "$type": "Generator.OffsetLines.TextLine, Generator",

--- a/app/src/main/jni/Includes/Source.h
+++ b/app/src/main/jni/Includes/Source.h
@@ -81,11 +81,13 @@ namespace il2cpp {
 
     void (*il2cpp_thread_detach)(void *thread);
 
-    uint(*il2cpp_gchandle_new)(void *object, bool weak);
+    // Since 36.2 (metadata v39) il2cpp returns a 64-bit gc handle, storing it in a
+    // 32-bit type truncates the value and the next free/get_target faults.
+    uintptr_t (*il2cpp_gchandle_new)(void *object, bool weak);
 
-    void (*il2cpp_gchandle_free)(uint gchandle);
+    void (*il2cpp_gchandle_free)(uintptr_t gchandle);
 
-    Il2CppObject* (*il2cpp_gchandle_get_target)(uint32_t gchandle);
+    Il2CppObject* (*il2cpp_gchandle_get_target)(uintptr_t gchandle);
 
     void *(*il2cpp_array_new_specific)(Il2CppClass *arrayTypeInfo, size_t length);
 

--- a/app/src/main/jni/Includes/Source.h
+++ b/app/src/main/jni/Includes/Source.h
@@ -213,7 +213,7 @@ namespace il2cpp {
 
     void (*ThinkEmoteManager_Update)(ThinkEmoteManager_o *_this);
 
-    void (*SocialToastMgr_AddToast)(SocialToastMgr_o *_this, Il2CppObject *blocker, System_String_o *textArg, Il2CppObject *toastType, float displayTime, bool playSound);
+    void (*SocialToastMgr_AddToast)(SocialToastMgr_o *_this, int blocker, System_String_o *textArg, int toastType, float displayTime, bool playSound);
 
     void (*Network_Update)(Network_o * _this);
 

--- a/app/src/main/jni/Main.cpp
+++ b/app/src/main/jni/Main.cpp
@@ -192,7 +192,7 @@ BnetRegion Hearthstone_Devices_DeviceLocaleHelper_GetCurrentRegionId() {
     return il2cpp::Hearthstone_Devices_DeviceLocaleHelper_GetCurrentRegionId();
 }
 
-void SocialToastMgr_AddToast(SocialToastMgr_o *_this, Il2CppObject *blocker, System_String_o *textArg, Il2CppObject *toastType, float displayTime, bool playSound) {
+void SocialToastMgr_AddToast(SocialToastMgr_o *_this, int blocker, System_String_o *textArg, int toastType, float displayTime, bool playSound) {
     displayTime *= timeScale;
     il2cpp::SocialToastMgr_AddToast(_this, blocker, textArg, toastType, displayTime, playSound);
 }
@@ -264,8 +264,7 @@ TAG_PREMIUM EntityBase_GetPremiumType(EntityBase_o *_this) {
 }
 
 void Entity_LoadCard(Entity_o *_this, System_String_o *cardId, Entity_LoadCardData_o *data, bool async) {
-    *reinterpret_cast<int *>(&_this->fields.m_realTimePremium) = static_cast<int>(EntityBase_GetPremiumType(reinterpret_cast<EntityBase_o *>(_this)));
-    
+    _this->fields.m_realTimePremium = static_cast<int>(EntityBase_GetPremiumType(reinterpret_cast<EntityBase_o *>(_this)));
     il2cpp::Entity_LoadCard(_this, cardId, data, async);
 }
 

--- a/app/src/main/jni/Main.cpp
+++ b/app/src/main/jni/Main.cpp
@@ -59,7 +59,7 @@ int m_chainedEnemyEmotes;
 
 std::mutex deviceNameMutex, currentOpponentMutex;
 
-uint currentOpponent_gchandle = -1;
+uintptr_t currentOpponent_gchandle = -1;
 
 // Do not change or translate the first text unless you know what you are doing
 // Assigning feature numbers is optional. Without it, it will automatically count for you, starting from 0
@@ -814,9 +814,9 @@ void hack_thread() {
     il2cpp::il2cpp_domain_get = reinterpret_cast<void *(*)()>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_domain_get")));
     il2cpp::il2cpp_thread_attach = reinterpret_cast<void *(*)(void *domain)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_thread_attach")));
     il2cpp::il2cpp_thread_detach = reinterpret_cast<void (*)(void *thread)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_thread_detach")));
-    il2cpp::il2cpp_gchandle_new = reinterpret_cast<uint(*)(void *object, bool weak)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_gchandle_new")));
-    il2cpp::il2cpp_gchandle_free = reinterpret_cast<void (*)(uint gchandle)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_gchandle_free")));
-    il2cpp::il2cpp_gchandle_get_target = reinterpret_cast<Il2CppObject* (*)(uint32_t gchandle)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_gchandle_get_target")));
+    il2cpp::il2cpp_gchandle_new = reinterpret_cast<uintptr_t (*)(void *object, bool weak)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_gchandle_new")));
+    il2cpp::il2cpp_gchandle_free = reinterpret_cast<void (*)(uintptr_t gchandle)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_gchandle_free")));
+    il2cpp::il2cpp_gchandle_get_target = reinterpret_cast<Il2CppObject* (*)(uintptr_t gchandle)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_gchandle_get_target")));
 
     il2cpp::il2cpp_string_new = reinterpret_cast<System_String_o * (*)(const char *text)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_string_new")));
     il2cpp::il2cpp_string_new_utf16 = reinterpret_cast<System_String_o * (*)(const Il2CppChar * text, int len)>(getAbsoluteAddress(targetLibName, OBFUSCATE("il2cpp_string_new_utf16")));

--- a/patches/Il2CppDumper-enum-metadata-v32plus.patch
+++ b/patches/Il2CppDumper-enum-metadata-v32plus.patch
@@ -1,0 +1,69 @@
+--- a/Il2CppDumper/Utils/Il2CppExecutor.cs
++++ b/Il2CppDumper/Utils/Il2CppExecutor.cs
+@@ -485,6 +485,19 @@
+             }
+         }
+ 
++        // Metadata >= 32 (Unity 6) removed Il2CppTypeDefinition.elementTypeIndex, so it stays 0 and
++        // il2Cpp.types[0] resolves to an unrelated (reference) type - every enum would then be
++        // emitted as an 8-byte pointer instead of its 4-byte underlying type, shifting struct layouts.
++        // An enum's underlying type is always the type of its first instance field ("value__").
++        public Il2CppType GetEnumUnderlyingType(Il2CppTypeDefinition typeDef)
++        {
++            if (il2Cpp.Version <= 31)
++            {
++                return il2Cpp.types[typeDef.elementTypeIndex];
++            }
++            return il2Cpp.types[metadata.fieldDefs[typeDef.fieldStart].typeIndex];
++        }
++
+         public Il2CppTypeEnum ReadEncodedTypeEnum(BinaryReader reader, out Il2CppType enumType)
+         {
+             enumType = null;
+@@ -494,7 +507,7 @@
+                 var enumTypeIndex = reader.ReadCompressedInt32();
+                 enumType = il2Cpp.types[enumTypeIndex];
+                 var typeDef = GetTypeDefinitionFromIl2CppType(enumType);
+-                type = il2Cpp.types[typeDef.elementTypeIndex].type;
++                type = GetEnumUnderlyingType(typeDef).type;
+             }
+             return type;
+         }
+--- a/Il2CppDumper/Outputs/StructGenerator.cs
++++ b/Il2CppDumper/Outputs/StructGenerator.cs
+@@ -586,7 +586,7 @@
+                         var typeDef = executor.GetTypeDefinitionFromIl2CppType(il2CppType);
+                         if (typeDef.IsEnum)
+                         {
+-                            return ParseType(il2Cpp.types[typeDef.elementTypeIndex]);
++                            return ParseType(executor.GetEnumUnderlyingType(typeDef));
+                         }
+                         return structNameDic[typeDef] + "_o";
+                     }
+@@ -628,7 +628,7 @@
+                         {
+                             if (typeDef.IsEnum)
+                             {
+-                                return ParseType(il2Cpp.types[typeDef.elementTypeIndex]);
++                                return ParseType(executor.GetEnumUnderlyingType(typeDef));
+                             }
+                             return typeStructName + "_o";
+                         }
+@@ -1300,7 +1300,7 @@
+                         var typeDef = executor.GetTypeDefinitionFromIl2CppType(il2CppType);
+                         if (typeDef.IsEnum)
+                         {
+-                            return IsCustomType(il2Cpp.types[typeDef.elementTypeIndex], context);
++                            return IsCustomType(executor.GetEnumUnderlyingType(typeDef), context);
+                         }
+                         return true;
+                     }
+@@ -1310,7 +1310,7 @@
+                         var typeDef = executor.GetGenericClassTypeDefinition(genericClass);
+                         if (typeDef.IsEnum)
+                         {
+-                            return IsCustomType(il2Cpp.types[typeDef.elementTypeIndex], context);
++                            return IsCustomType(executor.GetEnumUnderlyingType(typeDef), context);
+                         }
+                         return true;
+                     }


### PR DESCRIPTION
Three separate problems on 36.2.248348, all reproducible on a clean install: the client crashes as soon as a card is rendered, Battlegrounds crashes on the shop-to-combat transition, and cards and Bob lose their voice lines. Every fix below was verified on a device (Xiaomi, Android 14, arm64) with an APK built by this workflow.

### 1. The dumper emits every enum as a pointer, which shifts all struct layouts

36.2 bumped IL2CPP metadata v31 to v39, so the build switched to `c01ns/Il2CppDumper`. That fork marks `Il2CppTypeDefinition.elementTypeIndex` as `[Version(Max = 31)]`, but `StructGenerator` still resolves an enum's underlying type through it, so on metadata > 31 the index is always 0 and every enum field and parameter is emitted as an 8-byte `Il2CppObject*` instead of `int32_t`.

That is not only the `m_realTimePremium` crash. Checked against the field offsets in `dump.cs`:

| field | in the build | in the game |
|---|---|---|
| `Entity.m_realTimePremium` | 0xD0 | 0xC8 |
| `Player.m_gameAccountId` | 0x128 | 0x120 |
| `SharedPlayerInfo.m_gameAccountId` | 0x120 | 0x118 |
| `PlayerLeaderboardCard.m_playerHeroEntity` | 0xA8 | 0xA0 |
| `PlayerLeaderboardCard.m_mousedOver` | 0xC0 | 0xB8 |

`patches/Il2CppDumper-enum-metadata-v32plus.patch` resolves the underlying type from the enum's first instance field (`value__`) when metadata > 31, and the workflow now builds the dumper from a pinned source revision with that patch instead of downloading the release. With it, `struct Entity_Fields` and `script.json` come out byte-identical to a known-good dump of the same `libil2cpp.so`.

There is also a new guard step: if `Entity.m_realTimePremium` is not an `int32_t` in the generated `il2cpp.h`, the build fails instead of shipping an APK whose every struct offset is wrong.

With correct headers the workarounds are no longer needed, so `Entity_LoadCard` assigns the field directly again and `SocialToastMgr_AddToast` takes its two enum parameters. Note that the current workaround in 971d652 writes at the shifted offset (0xD0, where `m_realTimePlayerTechLevel`/`m_realTimePlayerFightsFirst` live) rather than at the field itself - it stops the segfault but silently corrupts the entity.

### 2. GC handles are 64-bit since 36.2

`il2cpp_gchandle_new` used to return a 32-bit handle index; in 36.2 (Unity 6000.3.11f1) it returns a 64-bit pointer, and `il2cpp_gchandle_free` dereferences it:

```
36.0:  il2cpp_gchandle_new_weakref: ... ldr w19, [sp] ... mov w0, w19
36.2:  il2cpp_gchandle_new_weakref: ... ldr x19, [sp] ... mov x0, x19
36.2:  il2cpp_gchandle_free: b <GC block lookup>
           and  x22, x0, #0xffffffffffffe000
           ldrb w8,  [x22, #32]          // faults on a truncated pointer
```

Storing that in `uint` drops the upper half, so the second `UpdateCurrentOpponent` in a match - the one `PlayerLeaderboardManager::SetCurrentOpponent` triggers when Battlegrounds moves from the shop to combat - frees a truncated pointer and crashes with `SIGSEGV ... fault addr 0x00000000f898e020`, which is exactly `(handle & ~0x1fff) + 0x20`. Using `uintptr_t` for the handle and for the three `il2cpp_gchandle_*` signatures fixes it and stays correct on 32-bit builds.

### 3. The data directory override breaks audio

`0001-AndroidMixMod.patch` rewrote `FileUtils.GetInternalFilesDir()` to return `getExternalFilesDir(null)`, so a modded install keeps its content in `/sdcard/Android/data/<pkg>/files` while the client's own bookkeeping does not follow. The result is that the game treats content it has already downloaded as not installed: card and hero voice lines silently fall back to the generic sound, and `Sound.log` fills with

```
LoadAudioClipWithFallback failed to load DEEP_015_ProstheticArm_Play.wav:39c72d61c3f062941ab6e7c89cdc36e5. Falling back to muted enUS asset
```

for 18 different clips in a single Battlegrounds match. This is not missing or damaged content: the catalog in `asset_manifest.unity3d` resolves that guid to `playsound_base_global-b10736ab-audio-0.unity3d`, the file is present in the data folder, and unpacking it locally shows the 35 clips it should contain. `Asset.log` shows the game never even opens the bundle - `playsound_*` and `soundotherminion_*` are not touched once in a whole session.

The override is not needed: Hearthstone picks its data directory in `FileUtils.GetFilesDir()` according to its own `FilesDirType` preference. Dropping the hunk restores working audio, and on a modern device it costs nothing - `/sdcard` is emulated storage on the same partition as `/data`, so nothing was saved by moving the data there.

Ruling out the alternatives: the assets in the repacked APK are byte-identical to the original (all 464 `assets/` entries match by CRC and compression method), and a build with every hook and byte patch disabled still had no audio, so neither the repack nor the native side is involved.
